### PR TITLE
add importCodeMap

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -3,7 +3,7 @@
 
 
 # Why?
-flake-parts uses module system, which allows great modularization of your flake.
+flake-parts uses the nixos module system, which allows great modularization of your flake. This library allows you to easily setup your flake to automatically import these modules for you (just remember to add them to your VCS for them to show up).
 
 # How?
 See `./examples/mkFlake/flake.nix` and `./examples/importModules/flake.nix`. This library takes a `modulesDir` and imports and exports modules automatically from the following paths:
@@ -18,5 +18,22 @@ To be compatible with existing module systems, these `moduleKind` are treated sp
 
 
 
-# Disadvantages:
-- There is no way to specify which modules should not be imported/exported, so all modules are both imported and exported. To customize this you have to adapt the logic in `./modules/flake-parts/all-modules.nix`
+# Pros and Cons:
+
+- `flake-parts-auto.importModules`
+    - Pros:
+        - easy setup (see examples)
+    - Cons:
+        - locked to the folder structure
+        - There is no way to specify which modules should not be imported/exported, so all modules are both imported and exported. To customize this you have to adapt the logic in `./modules/flake-parts/all-modules.nix`
+
+- `flake-parts-auto.mkFlake` (Since this is a convenience wrapper around `flake-parts-auto.importModules` all of its pros and cons also apply)
+    - forces you to not write anything else in the `flake.nix`. This can be viewed as a pro or a con depending on the viewpoint.
+
+- `flake-parts-auto.importCodemap`
+    - Pros:
+        - allows user specified layout of folder structure.
+        - allows specifying which modules should be exported as well.
+        - serves as the documentation where things are located.
+    - Cons:
+        - more complex than `flake-parts-auto.importModules`

--- a/examples/importCodeMap/flake.lock
+++ b/examples/importCodeMap/flake.lock
@@ -18,6 +18,26 @@
         "type": "github"
       }
     },
+    "flake-parts-auto": {
+      "inputs": {
+        "flake-parts": [
+          "flake-parts"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 0,
+        "narHash": "sha256-mIYfyDfp1Tg/l1fJvaUOW0xHGP5Lbiy+NIkeD5HV8+s=",
+        "path": "../../.",
+        "type": "path"
+      },
+      "original": {
+        "path": "../../.",
+        "type": "path"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1694959747,
@@ -55,6 +75,7 @@
     "root": {
       "inputs": {
         "flake-parts": "flake-parts",
+        "flake-parts-auto": "flake-parts-auto",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/examples/importCodeMap/flake.lock
+++ b/examples/importCodeMap/flake.lock
@@ -29,7 +29,7 @@
       },
       "locked": {
         "lastModified": 0,
-        "narHash": "sha256-mIYfyDfp1Tg/l1fJvaUOW0xHGP5Lbiy+NIkeD5HV8+s=",
+        "narHash": "sha256-41qJ8U/hEBvwGn+tIuF136Nw1Gs47SmBYRQw/TIyZ7M=",
         "path": "../../.",
         "type": "path"
       },

--- a/examples/importCodeMap/flake.nix
+++ b/examples/importCodeMap/flake.nix
@@ -1,0 +1,33 @@
+{
+  description = "Example flake for using flake-parts-auto";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    flake-parts-auto={
+      url = "path:../../.";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.flake-parts.follows = "flake-parts";
+    };
+  };
+
+  outputs = inputs@{ flake-parts, self, ... }:
+  flake-parts.lib.mkFlake { inherit inputs; } {
+    systems = [ "x86_64-linux" ];
+    imports = [
+      (inputs.flake-parts-auto.importCodeMap (with inputs.flake-parts-auto.lib;{
+        # imports AND exports flake-parts modules from ./modules/flake-parts/<modulename>.nix
+        flake-parts = types.modules.flake-parts {};
+        # exports flake-parts modules from ./modules/custom-folder/<modulename>.nix
+        custom-folder = types.modules.flake-parts {import=false;};
+        # imports flake-parts modules from ./modules/private-flake-parts/<modulename>.nix
+        private-flake-parts = types.modules.flake-parts {export=false;};
+
+
+        
+
+
+      }) ./modules )
+    ];
+  };
+}

--- a/examples/importCodeMap/flake.nix
+++ b/examples/importCodeMap/flake.nix
@@ -15,16 +15,23 @@
   flake-parts.lib.mkFlake { inherit inputs; } {
     systems = [ "x86_64-linux" ];
     imports = [
-      (inputs.flake-parts-auto.importCodeMap (with inputs.flake-parts-auto.lib;{
+      (inputs.flake-parts-auto.importCodeMap (with inputs.flake-parts-auto.lib.types;{
         # imports AND exports flake-parts modules from ./modules/flake-parts/<modulename>.nix
-        flake-parts = types.modules.flake-parts {};
+        flake-parts = modules {};
         # exports flake-parts modules from ./modules/custom-folder/<modulename>.nix
-        custom-folder = types.modules.flake-parts {import=false;};
+        custom-folder = modules {import=false;};
         # imports flake-parts modules from ./modules/private-flake-parts/<modulename>.nix
-        private-flake-parts = types.modules.flake-parts {export=false;};
+        private-flake-parts = modules {export=false;};
+
+        nested = {
+          some_module = module {export=false;};
+        };
 
 
-        
+        nested_multi = directories (modules {export=false;});
+
+        # TODO: when doing this, it gives bad error message. It should be better, to indicate that it tries to import D
+        #nested_multi = directories (modules {export=false;});
 
 
       }) ./modules )

--- a/examples/importCodeMap/modules/flake-parts/packages.nix
+++ b/examples/importCodeMap/modules/flake-parts/packages.nix
@@ -1,5 +1,5 @@
 {
   perSystem = {pkgs,...}:{
     packages.default = pkgs.hello;
-  }
+  };
 }

--- a/examples/importCodeMap/modules/nested/some_module.nix
+++ b/examples/importCodeMap/modules/nested/some_module.nix
@@ -1,0 +1,3 @@
+{
+  config.flake.discovered_modules = builtins.trace "Imported module nested/some_module.nix" [];
+}

--- a/examples/importCodeMap/modules/nested_multi/module_collection_A/module1.nix
+++ b/examples/importCodeMap/modules/nested_multi/module_collection_A/module1.nix
@@ -1,0 +1,3 @@
+{
+  config.flake.discovered_modules = builtins.trace "Imported module nested_multi/module_collection_A/module1.nix" [];
+}

--- a/examples/importCodeMap/modules/nested_multi/module_collection_A/module2.nix
+++ b/examples/importCodeMap/modules/nested_multi/module_collection_A/module2.nix
@@ -1,0 +1,3 @@
+{
+  config.flake.discovered_modules = builtins.trace "Imported module nested_multi/module_collection_A/module2.nix" [];
+}

--- a/examples/importCodeMap/modules/nested_multi/module_collection_B/module3.nix
+++ b/examples/importCodeMap/modules/nested_multi/module_collection_B/module3.nix
@@ -1,0 +1,3 @@
+{
+  config.flake.discovered_modules = builtins.trace "Imported module nested_multi/module_collection_B/module3.nix" [];
+}

--- a/examples/importCodeMap/modules/nested_multi/module_collection_B/module4.nix
+++ b/examples/importCodeMap/modules/nested_multi/module_collection_B/module4.nix
@@ -1,0 +1,3 @@
+{
+  config.flake.discovered_modules = builtins.trace "Imported module nested_multi/module_collection_B/module3.nix" [];
+}

--- a/examples/importModules/flake.nix
+++ b/examples/importModules/flake.nix
@@ -11,7 +11,7 @@
   };
 
   outputs = inputs@{ flake-parts, self, ... }:
-  flake-parts.mkFlake { inherit inputs; } {
+  flake-parts.lib.mkFlake { inherit inputs; } {
     imports = [
       (inputs.flake-parts-auto.importModules ../modules)
     ];

--- a/examples/importModules/modules/flake-parts/packages.nix
+++ b/examples/importModules/modules/flake-parts/packages.nix
@@ -1,0 +1,5 @@
+{
+  perSystem = {pkgs,...}:{
+    packages.default = pkgs.hello;
+  };
+}

--- a/examples/mkFlake/modules/flake-parts/packages.nix
+++ b/examples/mkFlake/modules/flake-parts/packages.nix
@@ -1,0 +1,5 @@
+{
+  perSystem = {pkgs,...}:{
+    packages.default = pkgs.hello;
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -11,14 +11,15 @@
   '';
 
   inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-parts.url = "github:hercules-ci/flake-parts";
   };
 
   outputs = inputs @ {flake-parts, ...}:
-    flake-parts.lib.mkFlake {inherit inputs;} {
-      systems = [];
-      imports = [
-        (import ./modules/flake-parts/all-modules.nix ./modules)
-      ];
-    };
+  flake-parts.lib.mkFlake {inherit inputs;} {
+    systems = [];
+    imports = [
+      (import ./modules/flake-parts/all-modules.nix ./modules)
+    ];
+  };
 }

--- a/modules/flake-parts/codemapped-modules.nix
+++ b/modules/flake-parts/codemapped-modules.nix
@@ -1,0 +1,44 @@
+# This function builds a flake-parts module that conditionally imports the
+# modules a codemap defines.
+{self,inputs,...}:
+{
+  config.flake.importCodeMap =
+  let importCodeMap =
+    # The specification of the codemap to be imported
+    codeMap:
+    # The Path where it all starts.
+    codeMapDir:
+  let
+    # Ensure that codeMapDir is a list:
+    codeMapDirList =
+      if (builtins.isList codeMapDir) then
+        codeMapDir
+      else if (builtins.isPath codeMapDir) then
+        [ codeMapDir ]
+      else
+        (builtins.throw "The codeMapDir is of invalid type.");
+  in
+  if (! builtins.pathExists (builtins.concatStringsSep "/" codeMapDirList)) then
+    # If the path does not exist, we ignore it.
+    ((_:break _) {})
+  else if (builtins.isAttrs codeMap) then
+    # An attrset is treated like a directory of codeMaps, where each key represents
+    # a different path to modules. These path names are only for discoverability
+    # and do not affect the resulting import/export process.
+    {
+      imports = inputs.nixpkgs.lib.mapAttrsToList (name: codeMap: importCodeMap codeMap (codeMapDirList ++ [name])) codeMap;
+    }
+  else if (builtins.isFunction codeMap) then
+    # If it is a function, it gets given the codeMapDir and imported.
+    {
+      imports = [ (codeMap codeMapDirList) ];
+    }
+  else
+    (builtins.throw "The Codemap is of invalid type.")
+  ;
+  in importCodeMap;
+}
+
+
+# TODO:
+# - (builtins.pathExists )

--- a/modules/flake-parts/importCodeMap.nix
+++ b/modules/flake-parts/importCodeMap.nix
@@ -17,16 +17,21 @@
         [ codeMapDir ]
       else
         (builtins.throw "The codeMapDir is of invalid type.");
+    codeMapDirPath = builtins.concatStringsSep "/" codeMapDirList;
   in
-  if (! builtins.pathExists (builtins.concatStringsSep "/" codeMapDirList)) then
+  if builtins.trace "Importing codemap from ${codeMapDirPath}" (! builtins.pathExists codeMapDirPath) then
     # If the path does not exist, we ignore it.
-    ((_:break _) {})
+    builtins.trace "The path ${codeMapDirPath} is not present, skipping import." {}
   else if (builtins.isAttrs codeMap) then
     # An attrset is treated like a directory of codeMaps, where each key represents
     # a different path to modules. These path names are only for discoverability
     # and do not affect the resulting import/export process.
+    let
+      importCodeMapInSubdir =
+      directoryName: innerCodeMap: importCodeMap innerCodeMap (codeMapDirList ++ [directoryName]);
+    in
     {
-      imports = inputs.nixpkgs.lib.mapAttrsToList (name: codeMap: importCodeMap codeMap (codeMapDirList ++ [name])) codeMap;
+      imports = inputs.nixpkgs.lib.mapAttrsToList importCodeMapInSubdir codeMap;
     }
   else if (builtins.isFunction codeMap) then
     # If it is a function, it gets given the codeMapDir and imported.

--- a/modules/flake-parts/templates.nix
+++ b/modules/flake-parts/templates.nix
@@ -1,0 +1,16 @@
+{
+  config.flake.templates = {
+    importModules = {
+      path = ../../examples/importModules;
+      description = "Example template for importModules";
+    };
+    mkFlake = {
+      path = ../../examples/mkFlake;
+      description = "Example template for mkFlake";
+    };
+    importCodeMap = {
+      path = ../../examples/importCodeMap;
+      description = "Example template for importCodeMap";
+    };
+  };
+}

--- a/modules/flake-parts/types.nix
+++ b/modules/flake-parts/types.nix
@@ -4,8 +4,7 @@ module-inputs @ {self,inputs,...}:{
       buildPath = list: (builtins.concatStringsSep "/" list) ;
     in
   rec {
-      module = {
-        flake-parts = {
+      modules = {
           # If true, the module will be exported as a flakeModule
           export ? true,
           # If true, the module will be imported into this flake.
@@ -15,79 +14,33 @@ module-inputs @ {self,inputs,...}:{
           # The path to the module, this is provided to the function by the library.
           modulePathSegments:
           let
-            flakePartsModule = builtins.import (buildPath modulePathSegments);
-            moduleName = inputs.nixpkgs.lib.lists.last modulePathSegments;
+            directoryContents = builtins.readDir (buildPath modulePathSegments);
+            directoryFiles = inputs.nixpkgs.lib.attrsets.filterAttrs (name: value: value == "regular")
+              directoryContents;
+            fileImporter = fileName: _: builtins.import (buildPath (modulePathSegments++[fileName]));
+            importedModules = builtins.mapAttrs (fileImporter) directoryFiles;
           in
-          builtins.trace
-            "Importing flake-parts module ${moduleName} from ${buildPath modulePathSegments}"
+          (builtins.trace
+            "Importing modules from ${buildPath modulePathSegments}/*"
           {
-            imports = if import then [ flakePartsModule ] else [];
+            imports = if import then (builtins.attrValues importedModules) else [];
             config.flake = if export then {
-              modules.flake-parts.${moduleName}=flakePartsModule;
-              flakeModules.${moduleName}=flakePartsModule;
+              modules.flake-parts=importedModules;
+              flakeModules=importedModules;
             } else {};
-          };
-        nixOs = {
-          export ? true
-        }:
+          });
+      directories = moduleType:
           # The path to the module, this is provided to the function by the library.
           modulePathSegments:
-          let
-            nixOsModule = import (buildPath modulePathSegments);
-            moduleName = inputs.nixpkgs.lib.lists.last modulePathSegments;
-          in
-          builtins.trace
-            "Importing nixos module ${moduleName} from ${buildPath modulePathSegments}"
-          {
-            config.flake = if export then {
-              modules.nixos.${moduleName}=nixOsModule;
-              nixosModules.${moduleName}=nixOsModule;
-            } else {};
-          };
-        darwin = {export?true}:
-          # The path to the module, this is provided to the function by the library.
-          modulePathSegments:
-          let
-            darwinModule = import (buildPath modulePathSegments);
-            moduleName = inputs.nixpkgs.lib.lists.last modulePathSegments;
-          in
-          builtins.trace
-            "Importing darwin module ${moduleName} from ${buildPath modulePathSegments}"
-          {
-            config.flake = if export then {
-              modules.darwin.${moduleName}=darwinModule;
-              darwinModules.${moduleName}=darwinModule;
-            } else {};
-          };
-        # These are exported automatically, because they cannot be imported
-        custom = {
-          name
-        }:
-        # The path to the module, this is provided to the function by the library.
-        modulePathSegments:
-        let
-            module = import (buildPath modulePathSegments);
-            moduleName = inputs.nixpkgs.lib.lists.last modulePathSegments;
-          in
-        builtins.trace
-            "Importing custom ${name} module ${moduleName} from ${buildPath modulePathSegments}"
-        {
-          config.flake.modules.${name}.${moduleName}=module;
-        };
-      };
-
-      directory = moduleType:
-          # The path to the module, this is provided to the function by the library.
-          modulePathSegments:
-      builtins.trace
-            "Importing directory from ${buildPath modulePathSegments}"
+      # builtins.trace
+      #       "Importing directory from ${buildPath modulePathSegments}"
       (let
-        directoryContents = builtins.attrNames (builtins.readDir (buildPath modulePathSegments));
-        importContent = content:
-          let
-            importPath = modulePathSegments ++ [content];
-          in
-            self.importCodeMap moduleType importPath;
+        directoryContents = builtins.attrNames
+          (inputs.nixpkgs.lib.attrsets.filterAttrs (name: value: value == "directory")
+          (builtins.readDir
+          (buildPath modulePathSegments
+          )));
+        importContent = content: self.importCodeMap moduleType (modulePathSegments ++ [content]);
       in
       {
         imports = builtins.map importContent directoryContents;
@@ -99,14 +52,8 @@ module-inputs @ {self,inputs,...}:{
             "Importing nested directory from ${buildPath modulePathSegments}"
       {
           # TODO: check that moduleType is not in itself a nestedDirectory or directory
+          # inputs.nixpkgs.lib.filesystem.listFilesRecursive
       };
 
-
-      modules = {
-        flake-parts = options: directory (module.flake-parts options);
-        nixOs = options: directory (module.nixOs options);
-        darwin = options: directory (module.darwin options);
-        custom = options: directory (module.custom options);
-      };
   };
 }

--- a/modules/flake-parts/types.nix
+++ b/modules/flake-parts/types.nix
@@ -1,0 +1,112 @@
+module-inputs @ {self,inputs,...}:{
+  config.flake.lib.types =
+    let
+      buildPath = list: (builtins.concatStringsSep "/" list) ;
+    in
+  rec {
+      module = {
+        flake-parts = {
+          # If true, the module will be exported as a flakeModule
+          export ? true,
+          # If true, the module will be imported into this flake.
+          # This allows for easy dogfooding and splitting of modules.
+          import ? true
+          }:
+          # The path to the module, this is provided to the function by the library.
+          modulePathSegments:
+          let
+            flakePartsModule = builtins.import (buildPath modulePathSegments);
+            moduleName = inputs.nixpkgs.lib.lists.last modulePathSegments;
+          in
+          builtins.trace
+            "Importing flake-parts module ${moduleName} from ${buildPath modulePathSegments}"
+          {
+            imports = if import then [ flakePartsModule ] else [];
+            config.flake = if export then {
+              modules.flake-parts.${moduleName}=flakePartsModule;
+              flakeModules.${moduleName}=flakePartsModule;
+            } else {};
+          };
+        nixOs = {
+          export ? true
+        }:
+          # The path to the module, this is provided to the function by the library.
+          modulePathSegments:
+          let
+            nixOsModule = import (buildPath modulePathSegments);
+            moduleName = inputs.nixpkgs.lib.lists.last modulePathSegments;
+          in
+          builtins.trace
+            "Importing nixos module ${moduleName} from ${buildPath modulePathSegments}"
+          {
+            config.flake = if export then {
+              modules.nixos.${moduleName}=nixOsModule;
+              nixosModules.${moduleName}=nixOsModule;
+            } else {};
+          };
+        darwin = {export?true}:
+          # The path to the module, this is provided to the function by the library.
+          modulePathSegments:
+          let
+            darwinModule = import (buildPath modulePathSegments);
+            moduleName = inputs.nixpkgs.lib.lists.last modulePathSegments;
+          in
+          builtins.trace
+            "Importing darwin module ${moduleName} from ${buildPath modulePathSegments}"
+          {
+            config.flake = if export then {
+              modules.darwin.${moduleName}=darwinModule;
+              darwinModules.${moduleName}=darwinModule;
+            } else {};
+          };
+        # These are exported automatically, because they cannot be imported
+        custom = {
+          name
+        }:
+        # The path to the module, this is provided to the function by the library.
+        modulePathSegments:
+        let
+            module = import (buildPath modulePathSegments);
+            moduleName = inputs.nixpkgs.lib.lists.last modulePathSegments;
+          in
+        builtins.trace
+            "Importing custom ${name} module ${moduleName} from ${buildPath modulePathSegments}"
+        {
+          config.flake.modules.${name}.${moduleName}=module;
+        };
+      };
+
+      directory = moduleType:
+          # The path to the module, this is provided to the function by the library.
+          modulePathSegments:
+      builtins.trace
+            "Importing directory from ${buildPath modulePathSegments}"
+      (let
+        directoryContents = builtins.attrNames (builtins.readDir (buildPath modulePathSegments));
+        importContent = content:
+          let
+            importPath = modulePathSegments ++ [content];
+          in
+            self.importCodeMap moduleType importPath;
+      in
+      {
+        imports = builtins.map importContent directoryContents;
+      });
+      nestedDirectory = moduleType:
+          # The path to the module, this is provided to the function by the library.
+          modulePathSegments:
+      builtins.trace
+            "Importing nested directory from ${buildPath modulePathSegments}"
+      {
+          # TODO: check that moduleType is not in itself a nestedDirectory or directory
+      };
+
+
+      modules = {
+        flake-parts = options: directory (module.flake-parts options);
+        nixOs = options: directory (module.nixOs options);
+        darwin = options: directory (module.darwin options);
+        custom = options: directory (module.custom options);
+      };
+  };
+}


### PR DESCRIPTION
importCodeMap allows definition of a "Codemap". Essentially a descriptive way to define from where modules should be imported and if these modules should be imported and/or exported.